### PR TITLE
Patch for Racket 7

### DIFF
--- a/protocol/json-util.rkt
+++ b/protocol/json-util.rkt
@@ -11,13 +11,14 @@
      (with-syntax ([(key_ ...) (generate-temporaries #'(key ...))]
                    [(keyword ...)
                     (for/list ([k (syntax->datum #'(key ...))])
-                      (string->keyword (symbol->string k)))])
+                      (string->keyword (symbol->string k)))]
+                   [??-id (quote-syntax ??)])
        (syntax/loc stx
          (define-match-expander name
            (λ (stx)
              (syntax-parse stx
                [(_ (~optional (~seq keyword key_)) ...)
-                (quasitemplate/loc stx (hash-table (?? ['key (? ctc key_)]) ...))]))
+                (quasitemplate/loc stx (hash-table (??-id ['key (? ctc key_)]) ...))]))
            (λ (stx)
              (syntax-parse stx
                [(_ (~optional (~seq keyword key_)) ...)


### PR DESCRIPTION
Apply patch from https://github.com/jeapostrophe/racket-langserver/commit/592220137c828724053ec57e7051ae541818a305.patch

closes #12 