### PR TITLE
fix symbol lookup feature

### DIFF
--- a/lang/lexer.rkt
+++ b/lang/lexer.rkt
@@ -183,7 +183,8 @@ ELECTRON
     (match mode
       [(? procedure?) mode]
       [(? pair?) (car mode)]
-      ['no-lang-line 'no-lang-line]))
+      ['no-lang-line 'no-lang-line]
+      ['before-lang-line 'before-lang-line]))
   (cond
     [(equal? mode-proc racket-lexer) 'racket]
     [(equal? mode-proc scribble-inside-lexer) 'scribble]


### PR DESCRIPTION
Currently **symbol lookup**/**document outline** list every single word in the document, this is not the expected behavior for the protocol, and the server might crash for big files (too many - thousands of - tokens to pass around). 

I think the expected behavior of the feature is to help user navigate around function/type definitions. 
This PR made it to only return function definitions (`(define xxx)`) and type definitions(`(define-type xxx)`). 

Now it is working as expected. 

![output2](https://user-images.githubusercontent.com/871037/78959810-113df400-7aba-11ea-9bc7-8159577e1b2d.gif)
